### PR TITLE
Please update tarantool.default for 1.6

### DIFF
--- a/1.6/tarantool.default
+++ b/1.6/tarantool.default
@@ -11,7 +11,6 @@ default_cfg = {
     pid_file   = "/var/run/tarantool", -- /var/run/tarantool/${INSTANCE}.pid
     wal_dir    = "/var/lib/tarantool", -- /var/lib/tarantool/${INSTANCE}/
     snap_dir   = "/var/lib/tarantool", -- /var/lib/tarantool/${INSTANCE}
-    vinyl_dir  = "/var/lib/tarantool", -- /var/lib/tarantool/${INSTANCE}
     logger     = "/var/log/tarantool", -- /var/log/tarantool/${INSTANCE}.log
     username   = "tarantool",
 }


### PR DESCRIPTION
I get this error when attempt to start any application inside a tarantool 1.6 docker image.
``` /usr/local/bin/tarantoolctl: Configuration failed: Incorrect value for option 'vinyl_dir': unexpected option ```

As far as I know there's no vinyl in 1.6 so maybe just remove the option from default config?