### PR TITLE
set proper 1.9.1 tag for centos dockerfile

### DIFF
--- a/1.x-centos7/Dockerfile
+++ b/1.x-centos7/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER mail@racktear.com
 RUN groupadd tarantool \
     && adduser -g tarantool tarantool
 
-ENV TARANTOOL_VERSION=1.9.1-11-gcd17b77f9 \
+ENV TARANTOOL_VERSION=1.9.1-0-g06ec3d50d \
     TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
     TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
     LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \


### PR DESCRIPTION
2018-05-28 10:41:22.697 [1] main/101/tarantool-entrypoint.lua C> Tarantool 1.9.1-0-g06ec3d5
