### PR TITLE
Build the lastest version of libicu

### DIFF
--- a/1.x-centos7/Dockerfile
+++ b/1.x-centos7/Dockerfile
@@ -45,7 +45,6 @@ RUN set -x \
         unzip \
         libunwind \
         libcurl \
-        libicu \
     && yum -y install \
         perl \
         gcc-c++ \
@@ -66,7 +65,18 @@ RUN set -x \
         go \
         wget \
         curl-devel \
-        libicu-devel \
+    && : "---------- libicu ----------" \
+    && wget http://download.icu-project.org/files/icu4c/62.1/icu4c-62_1-src.tgz \
+    && mkdir -p /usr/src/icu \
+        && tar -xzf icu4c-62_1-src.tgz -C /usr/src/icu --strip-components=1 \
+    && (cd /usr/src/icu/source; \
+        chmod +x runConfigureICU configure install-sh; \
+        ./runConfigureICU Linux/gcc; \
+        make; \
+        make install; \
+        echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf; \
+        cat /etc/ld.so.conf.d/local.conf; \
+        ldconfig )\
     && : "---------- gperftools ----------" \
     && yum install -y gperftools-libs \
     && (GOPATH=/usr/src/go go get github.com/google/pprof; \
@@ -114,6 +124,7 @@ RUN set -x \
     && rm -r /usr/src/luarocks \
     && rm -rf /usr/src/tarantool \
     && rm -rf /usr/src/go \
+    && rm -rf /usr/src/icu \
     && : "---------- remove build deps ----------" \
     && yum -y remove \
         perl \
@@ -138,7 +149,6 @@ RUN set -x \
         kernel-headers \
         golang-src \
         curl-devel \
-        libicu-devel \
     && rpm -qa | grep devel | xargs yum -y remove \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
A version in CentOS 7 repo is too old.
Added the building of the latest libicu version in Dockerfile 1.x-centos7

It closes https://github.com/tarantool/docker/issues/60