### PR TITLE
Add real wget in 1.* and 2.x docker files

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -50,6 +50,7 @@ RUN set -x \
         postgresql-dev \
         lua-dev \
         mariadb-dev \
+        wget \
     && : "---------- tarantool ----------" \
     && mkdir -p /usr/src/tarantool \
     && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -76,6 +76,7 @@ RUN set -x \
         libtool \
         linux-headers \
         go \
+        wget \
     && : "---------- gperftools ----------" \
     && mkdir -p /usr/src/gperftools \
     && git clone "$GPERFTOOLS_REPO" /usr/src/gperftools \

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -69,6 +69,7 @@ RUN set -x \
         go \
         curl-dev \
         icu-dev \
+        wget \
     && : "---------- gperftools ----------" \
     && mkdir -p /usr/src/gperftools \
     && git clone "$GPERFTOOLS_REPO" /usr/src/gperftools \

--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -70,6 +70,7 @@ RUN set -x \
         tcl \
         curl-dev \
         icu-dev \
+        wget \
     && : "---------- gperftools ----------" \
     && mkdir -p /usr/src/gperftools \
     && git clone "$GPERFTOOLS_REPO" /usr/src/gperftools \


### PR DESCRIPTION
It is needed to successfully pass github.com certificate validation. The
commit is follow up of 0ae0c261b0e6e79dc45a16bc3ca1db36cc5e4989.