### PR TITLE
Update 1.x-centos7 container to 1.10.2-185-g8a1a0a9ff and add curl build

### DIFF
--- a/1.x-centos7/Dockerfile
+++ b/1.x-centos7/Dockerfile
@@ -4,9 +4,11 @@ MAINTAINER mail@racktear.com
 RUN groupadd tarantool \
     && adduser -g tarantool tarantool
 
-ENV TARANTOOL_VERSION=1.10.2-179-ge5e259a82 \
+ENV TARANTOOL_VERSION=1.10.2-185-g8a1a0a9ff \
     TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
     TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
+    CURL_REPO=https://github.com/curl/curl.git \
+    CURL_TAG=curl-7_64_0 \
     LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \
     LUAROCK_SHARD_REPO=https://github.com/tarantool/shard.git \
     LUAROCK_SHARD_TAG=8f8c5a7 \
@@ -39,12 +41,11 @@ RUN set -x \
         ncurses \
         libgomp \
         lua \
-        curl \
         tar \
         zip \
         unzip \
         libunwind \
-        libcurl \
+        ca-certificates \
     && yum -y install \
         perl \
         gcc-c++ \
@@ -64,7 +65,6 @@ RUN set -x \
         libtool \
         go \
         wget \
-        curl-devel \
     && : "---------- libicu ----------" \
     && wget http://download.icu-project.org/files/icu4c/63.1/icu4c-63_1-src.tgz \
     && mkdir -p /usr/src/icu \
@@ -76,8 +76,17 @@ RUN set -x \
         make; \
         make install; \
         echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf; \
-        cat /etc/ld.so.conf.d/local.conf; \
-        ldconfig )\
+        ldconfig ) \
+    && : "---------- curl ----------" \
+    && mkdir -p /usr/src/curl \
+    && git clone "$CURL_REPO" /usr/src/curl \
+    && (cd /usr/src/curl; \
+        git checkout "$CURL_TAG"; \
+        ./buildconf; \
+        ./configure --with-ssl --prefix "/usr/local"; \
+        make -j; \
+        make install; \
+        ldconfig ) \
     && : "---------- gperftools ----------" \
     && yum install -y gperftools-libs \
     && (GOPATH=/usr/src/go go get github.com/google/pprof; \
@@ -126,6 +135,7 @@ RUN set -x \
     && rm -rf /usr/src/tarantool \
     && rm -rf /usr/src/go \
     && rm -rf /usr/src/icu \
+    && rm -rf /usr/src/curl \
     && : "---------- remove build deps ----------" \
     && yum -y remove \
         perl \
@@ -149,7 +159,6 @@ RUN set -x \
         perl \
         kernel-headers \
         golang-src \
-        curl-devel \
     && rpm -qa | grep devel | xargs yum -y remove \
     && rm -rf /var/cache/yum
 
@@ -162,11 +171,11 @@ RUN set -x \
         mariadb-libs \
         postgresql96-libs \
         cyrus-sasl \
-        libcurl \
         libev \
         proj \
         geos \
         unzip \
+        openssl-libs \
     && yum -y install \
         git \
         cmake \
@@ -175,7 +184,6 @@ RUN set -x \
         postgresql96-devel \
         lua-devel \
         cyrus-sasl-devel \
-        curl-devel \
         libev-devel \
         wget \
         proj-devel \
@@ -225,7 +233,6 @@ RUN set -x \
         postgresql96-devel \
         lua-devel \
         cyrus-sasl-devel \
-        curl-devel \
         libev-devel \
         wget \
         proj-devel \


### PR DESCRIPTION
This patch https://github.com/tarantool/tarantool/commit/a445cdfa8157df8be9b52e4fa1297297671b7a2b should fix a problem with fiber stack explosion. And now we can update curl to the latest version to get ability to use all features of new curl.