### PR TITLE
Fix wrong 2.x version from 2.1.2-2 to 2.2.0-128

### DIFF
--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -5,7 +5,7 @@ RUN addgroup -S tarantool \
     && adduser -S -G tarantool tarantool \
     && apk add --no-cache 'su-exec>=0.2'
 
-ENV TARANTOOL_VERSION=2.1.2-2-gd06f95fc1 \
+ENV TARANTOOL_VERSION=2.2.0-128-g7b56f1fef \
     TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
     TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
     CURL_REPO=https://github.com/curl/curl.git \


### PR DESCRIPTION
Wrongly cherry-picked the commit with 2.1.2 release for master branch.
Wrong commit was e7e709f2b5c1a887c176040ea3058a90c7b9a5d4