### PR TITLE
Remove tarantool-curl module from *.x Dockerfiles

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -23,7 +23,6 @@ ENV TARANTOOL_VERSION=1.7.6-27-g7ef5be2ee \
     LUAROCK_MEMCACHED_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_CURL_VERSION=2.3.1 \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.0 \
@@ -207,8 +206,6 @@ RUN set -x \
     && luarocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "prometheus" \
     && luarocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "curl" \
-    && luarocks install tarantool-curl $LUAROCK_TARANTOOL_CURL_VERSION \
     && : "mqtt" \
     && luarocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && : "gis" \

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -23,7 +23,6 @@ ENV TARANTOOL_VERSION=1.9.2-13-gfa7c74b4d \
     LUAROCK_MEMCACHED_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_CURL_VERSION=2.3.1 \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.0 \
@@ -207,8 +206,6 @@ RUN set -x \
     && luarocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "prometheus" \
     && luarocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "curl" \
-    && luarocks install tarantool-curl $LUAROCK_TARANTOOL_CURL_VERSION \
     && : "mqtt" \
     && luarocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && : "gis" \

--- a/1.x-centos7/Dockerfile
+++ b/1.x-centos7/Dockerfile
@@ -19,7 +19,6 @@ ENV TARANTOOL_VERSION=1.10.3-136-gc3c087d5c \
     LUAROCK_MEMCACHED_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_CURL_VERSION=2.3.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
@@ -210,8 +209,6 @@ RUN set -x \
     && luarocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "prometheus" \
     && luarocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "curl" \
-    && luarocks install tarantool-curl $LUAROCK_TARANTOOL_CURL_VERSION \
     && : "gis" \
     && luarocks install gis $LUAROCK_TARANTOOL_GIS_VERSION \
     && : "gperftools" \

--- a/1.x/Dockerfile
+++ b/1.x/Dockerfile
@@ -21,7 +21,6 @@ ENV TARANTOOL_VERSION=1.10.3-136-gc3c087d5c \
     LUAROCK_MEMCACHED_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_CURL_VERSION=2.3.1 \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.0 \
@@ -200,8 +199,6 @@ RUN set -x \
     && luarocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "prometheus" \
     && luarocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "curl" \
-    && luarocks install tarantool-curl $LUAROCK_TARANTOOL_CURL_VERSION \
     && : "mqtt" \
     && luarocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && : "gis" \

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -23,7 +23,6 @@ ENV TARANTOOL_VERSION=2.1.2-143-g3edaaed6c \
     LUAROCK_MEMCACHED_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_CURL_VERSION=2.3.1 \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.0 \
@@ -209,8 +208,6 @@ RUN set -x \
     && luarocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "prometheus" \
     && luarocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "curl" \
-    && luarocks install tarantool-curl $LUAROCK_TARANTOOL_CURL_VERSION \
     && : "mqtt" \
     && luarocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && : "gis" \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -23,7 +23,6 @@ ENV TARANTOOL_VERSION=2.2.1-3-g878e2a42c \
     LUAROCK_MEMCACHED_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_CURL_VERSION=2.3.1 \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.0 \
@@ -209,8 +208,6 @@ RUN set -x \
     && luarocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "prometheus" \
     && luarocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "curl" \
-    && luarocks install tarantool-curl $LUAROCK_TARANTOOL_CURL_VERSION \
     && : "mqtt" \
     && luarocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && : "gis" \

--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -21,7 +21,6 @@ ENV TARANTOOL_VERSION=2.3.0-117-g4c2d1eff2 \
     LUAROCK_MEMCACHED_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_CURL_VERSION=2.3.1 \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.0 \
@@ -204,8 +203,6 @@ RUN set -x \
     && luarocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "prometheus" \
     && luarocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "curl" \
-    && luarocks install tarantool-curl $LUAROCK_TARANTOOL_CURL_VERSION \
     && : "mqtt" \
     && luarocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && : "gis" \


### PR DESCRIPTION
tarantool-curl is old module, now we recommend to use on-board "http.client" module
And now it causes some problems with statically bundled curl. As quick fix let's remove it.