### PR TITLE
environment force recovery option

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ decreased if most of the tuples are very small. Default is 16.
 Optional. Specifies how often snapshots will be made, in seconds.
 Default is 3600 (every 1 hour).
 
+### `TARANTOOL_FORCE_RECOVERY`
+
+Optional. When set to "true" Tarantool tries to continue if there is an error while reading a snapshot file or a write-ahead log file. Skips invalid records, reads as much data as possible, print a warning in console and start the database.
+
 # Reporting problems and getting help
 
 You can report problems and request

--- a/files/tarantool-entrypoint.lua
+++ b/files/tarantool-entrypoint.lua
@@ -181,6 +181,7 @@ local function wrapper_cfg(override)
         file_cfg.TARANTOOL_SLAB_ALLOC_MINIMAL = os.getenv('TARANTOOL_SLAB_ALLOC_MINIMAL')
         file_cfg.TARANTOOL_SLAB_ALLOC_MAXIMAL = os.getenv('TARANTOOL_SLAB_ALLOC_MAXIMAL')
         file_cfg.TARANTOOL_PORT = os.getenv('TARANTOOL_PORT')
+        file_cfg.TARANTOOL_FORCE_RECOVERY = os.getenv('TARANTOOL_FORCE_RECOVERY')
         file_cfg.TARANTOOL_WAL_MODE = os.getenv('TARANTOOL_WAL_MODE')
         file_cfg.TARANTOOL_REPLICATION_SOURCE = os.getenv('TARANTOOL_REPLICATION_SOURCE')
         file_cfg.TARANTOOL_REPLICATION = os.getenv('TARANTOOL_REPLICATION')
@@ -233,6 +234,8 @@ local function wrapper_cfg(override)
         override.listen or TARANTOOL_DEFAULT_PORT
     cfg.wal_mode = file_cfg.TARANTOOL_WAL_MODE or
         override.wal_mode
+
+    cfg.force_recovery = file_cfg.TARANTOOL_FORCE_RECOVERY == 'true'
 
     cfg.wal_dir = override.wal_dir or '/var/lib/tarantool'
     cfg.vinyl_dir = override.vinyl_dir or '/var/lib/tarantool'

--- a/files/tarantool_set_config.lua
+++ b/files/tarantool_set_config.lua
@@ -86,6 +86,7 @@ local vars = {
     TARANTOOL_SLAB_ALLOC_MAXIMAL=nop,
     TARANTOOL_SLAB_ALLOC_MINIMAL=nop,
     TARANTOOL_PORT=nop,
+    TARANTOOL_FORCE_RECOVERY=nop,
     TARANTOOL_WAL_MODE=nop,
     TARANTOOL_USER_NAME=update_credentials,
     TARANTOOL_USER_PASSWORD=update_credentials,


### PR DESCRIPTION
Sometimes workdir contains invalid files due unexpected shutdown. Tarantool has an option to recover from this corrupted data, but this can't be managed from envrionment. This patch proxy env flag to box.cfg