### PR TITLE
Default metrics configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ Tarantool. In the above example, it is set to "mysecretpassword".
 Optional. Specifying this variable will tell Tarantool to listen for
 incoming connections on a specific port. Default is 3301.
 
+### `TARANTOOL_PROMETHEUS_DEFAULT_METRICS_PORT`
+
+Optional. If specified tarantool will start http server on given port and expose prometheus `metrics` endpoint with common metrics (fibers, memory, network, replication, etc... )
+
 ### `TARANTOOL_REPLICATION`
 
 Optional. Comma-separated list of URIs to treat as replication

--- a/files/tarantool-entrypoint.lua
+++ b/files/tarantool-entrypoint.lua
@@ -264,6 +264,14 @@ local function wrapper_cfg(override)
 
     console.listen(CONSOLE_SOCKET_PATH)
 
+    local metrics_port = tonumber(os.getenv('TARANTOOL_PROMETHEUS_DEFAULT_METRICS_PORT')) or 0
+    if metrics_port > 0 then
+        require('metrics.default_metrics.tarantool').enable()
+        local prometheus = require('metrics.plugins.prometheus')
+        local httpd = require('http.server').new('0.0.0.0', metrics_port)
+        httpd:route( { path = '/metrics' }, prometheus.collect_http)
+        httpd:start()
+    end
 end
 
 box.cfg = wrapper_cfg


### PR DESCRIPTION
There are https and metrics modules on board, but there is no option to enable prometheus monitoring on standard docker image. Add environment option and extend readme.