### PR TITLE
Avoid of fails on additional pprof tool

### DIFF
--- a/dockerfiles/alpine_3.5_1.10.3
+++ b/dockerfiles/alpine_3.5_1.10.3
@@ -91,8 +91,8 @@ RUN set -x \
         ./configure; \
         make -j ; \
         cp .libs/libprofiler.so* /usr/local/lib;) \
-    && (GOPATH=/usr/src/go go get github.com/google/pprof; \
-        cp /usr/src/go/bin/pprof /usr/local/bin) \
+    && (GOPATH=/usr/src/go go get github.com/google/pprof && \
+        cp /usr/src/go/bin/pprof /usr/local/bin || true ) \
     && : "---------- tarantool ----------" \
     && mkdir -p /usr/src/tarantool \
     && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \

--- a/dockerfiles/alpine_3.5_1.x
+++ b/dockerfiles/alpine_3.5_1.x
@@ -84,8 +84,8 @@ RUN set -x \
         ./configure; \
         make -j ; \
         cp .libs/libprofiler.so* /usr/local/lib;) \
-    && (GOPATH=/usr/src/go go get github.com/google/pprof; \
-        cp /usr/src/go/bin/pprof /usr/local/bin) \
+    && (GOPATH=/usr/src/go go get github.com/google/pprof && \
+        cp /usr/src/go/bin/pprof /usr/local/bin || true ) \
     && : "---------- tarantool ----------" \
     && mkdir -p /usr/src/tarantool \
     && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \

--- a/dockerfiles/alpine_3.5_2.2
+++ b/dockerfiles/alpine_3.5_2.2
@@ -93,8 +93,8 @@ RUN set -x \
         ./configure; \
         make -j ; \
         cp .libs/libprofiler.so* /usr/local/lib;) \
-    && (GOPATH=/usr/src/go go get github.com/google/pprof; \
-        cp /usr/src/go/bin/pprof /usr/local/bin) \
+    && (GOPATH=/usr/src/go go get github.com/google/pprof && \
+        cp /usr/src/go/bin/pprof /usr/local/bin || true ) \
     && : "---------- tarantool ----------" \
     && mkdir -p /usr/src/tarantool \
     && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \

--- a/dockerfiles/alpine_3.5_2.x
+++ b/dockerfiles/alpine_3.5_2.x
@@ -81,8 +81,8 @@ RUN set -x \
         ./configure; \
         make -j ; \
         cp .libs/libprofiler.so* /usr/local/lib;) \
-    && (GOPATH=/usr/src/go go get github.com/google/pprof; \
-        cp /usr/src/go/bin/pprof /usr/local/bin) \
+    && (GOPATH=/usr/src/go go get github.com/google/pprof && \
+        cp /usr/src/go/bin/pprof /usr/local/bin || true ) \
     && : "---------- tarantool ----------" \
     && mkdir -p /usr/src/tarantool \
     && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \

--- a/dockerfiles/centos_7_1.x
+++ b/dockerfiles/centos_7_1.x
@@ -80,8 +80,8 @@ RUN set -x \
         ldconfig ) \
     && : "---------- gperftools ----------" \
     && yum install -y gperftools-libs \
-    && (GOPATH=/usr/src/go go get github.com/google/pprof; \
-        cp /usr/src/go/bin/pprof /usr/local/bin) \
+    && (GOPATH=/usr/src/go go get github.com/google/pprof && \
+        cp /usr/src/go/bin/pprof /usr/local/bin || true ) \
     && : "---------- tarantool ----------" \
     && mkdir -p /usr/src/tarantool \
     && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \

--- a/dockerfiles/centos_7_2.x
+++ b/dockerfiles/centos_7_2.x
@@ -78,8 +78,8 @@ RUN set -x \
         ldconfig ) \
     && : "---------- gperftools ----------" \
     && yum install -y gperftools-libs \
-    && (GOPATH=/usr/src/go go get github.com/google/pprof; \
-        cp /usr/src/go/bin/pprof /usr/local/bin) \
+    && (GOPATH=/usr/src/go go get github.com/google/pprof && \
+        cp /usr/src/go/bin/pprof /usr/local/bin || true ) \
     && : "---------- tarantool ----------" \
     && mkdir -p /usr/src/tarantool \
     && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \


### PR DESCRIPTION
Found that pprof tool installation became broken at the
github sources. Left the pprof tool installation at the
docker files but disabled it's return code to avoid of
iamges building failures dut to pprof was additional.
Error on pprof installation found:

$ sudo snap install go --classic
go 1.14.3 from Michael Hudson-Doyle (mwhudson) installed

$ GOPATH=/usr/src/go go get github.com/google/pprof ; echo $?
/usr/src/go/src/github.com/google/pprof/internal/driver/settings.go:27:14: undefined: os.UserConfigDir
2

Closes #147