### PR TITLE
gitlab-ci: always rebuild all images on master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,17 +10,18 @@ before_script:
   # Enable GitLab registry
   - docker login -u gitlab-ci-token -p ${CI_BUILD_TOKEN} ${REGISTRY}
 
-.force_build_template: &force_build_definition
-  only:
-    - /^.*-force-build$/
-
 .build_template: &build_definition
   stage: build
+  tags:
+    - deploy_test
   script:
     - >
-      if  ${CHECK_GIT} | grep "^versions/${OS}_${VER}$" || \
+      if  [ ${CI_COMMIT_REF_NAME} = master ] || \
+          ${CHECK_GIT} | grep "^versions/${OS}_${VER}$" || \
           ${CHECK_GIT} | grep "^dockerfiles/${OS}_${DVER}$" || \
-          ${CHECK_GIT} | grep "^files/"
+          ${CHECK_GIT} | grep "^files/" || \
+          ${CHECK_GIT} | grep "^.gitlab-ci.yml$" || \
+          ${CHECK_GIT} | grep "^.gitlab.mk$"
       then
         make -f .gitlab.mk build
       fi;
@@ -33,7 +34,6 @@ before_script:
 
 'alpine 3.5 1.10.0':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1.10.0'
@@ -43,7 +43,6 @@ before_script:
 
 'alpine 3.5 1.10.1':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1.10.1'
@@ -53,7 +52,6 @@ before_script:
 
 'alpine 3.5 1.10.2':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1.10.2'
@@ -63,7 +61,6 @@ before_script:
 
 'alpine 3.5 1.10.3':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1.10.3'
@@ -73,7 +70,6 @@ before_script:
 
 'alpine 3.5 1.10.4':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1.10.4'
@@ -83,7 +79,6 @@ before_script:
 
 'alpine 3.5 1.10.5':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1.10.5'
@@ -93,7 +88,6 @@ before_script:
 
 'alpine 3.5 1.10.6':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1.10.6'
@@ -103,7 +97,6 @@ before_script:
 
 'alpine 3.5 1.x':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '1'
@@ -115,7 +108,6 @@ before_script:
 
 'alpine 3.5 2.1.0':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.1.0'
@@ -125,7 +117,6 @@ before_script:
 
 'alpine 3.5 2.1.1':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.1.1'
@@ -135,7 +126,6 @@ before_script:
 
 'alpine 3.5 2.1.2':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.1.2'
@@ -145,7 +135,6 @@ before_script:
 
 'alpine 3.5 2.1.3':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.1.3'
@@ -155,7 +144,6 @@ before_script:
 
 'alpine 3.5 2.1':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.1'
@@ -167,7 +155,6 @@ before_script:
 
 'alpine 3.5 2.2.0':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.2.0'
@@ -177,7 +164,6 @@ before_script:
 
 'alpine 3.5 2.2.1':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.2.1'
@@ -187,7 +173,6 @@ before_script:
 
 'alpine 3.5 2.2.2':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.2.2'
@@ -197,7 +182,6 @@ before_script:
 
 'alpine 3.5 2.2.3':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.2.3'
@@ -207,7 +191,6 @@ before_script:
 
 'alpine 3.5 2.2':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.2'
@@ -219,7 +202,6 @@ before_script:
 
 'alpine 3.5 2.3.0':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.3.0'
@@ -229,7 +211,6 @@ before_script:
 
 'alpine 3.5 2.3.1':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.3.1'
@@ -239,7 +220,6 @@ before_script:
 
 'alpine 3.5 2.3.2':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.3.2'
@@ -249,7 +229,6 @@ before_script:
 
 'alpine 3.5 2.3':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.3'
@@ -261,7 +240,6 @@ before_script:
 
 'alpine 3.5 2.4.0':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.4.0'
@@ -271,7 +249,6 @@ before_script:
 
 'alpine 3.5 2.4.1':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.4.1'
@@ -281,7 +258,6 @@ before_script:
 
 'alpine 3.5 2.4':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.4'
@@ -293,7 +269,6 @@ before_script:
 
 'alpine 3.5 2.5.0':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2.5.0'
@@ -303,7 +278,6 @@ before_script:
 
 'alpine 3.5 2.x':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'alpine_3.5'
     TAG: '2'
@@ -320,7 +294,6 @@ before_script:
 
 'centos 7 1.x':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'centos_7'
     TAG: '1.x-centos7'
@@ -332,7 +305,6 @@ before_script:
 
 'centos 7 2.x':
   <<: *build_definition
-  <<: *force_build_definition
   variables:
     OS: 'centos_7'
     TAG: '2.x-centos7'


### PR DESCRIPTION
Added ability to run master branch with complete rebuild of all the
images. It is needed to run master branch in gitlab-ci schedules
regularly to detect missing packages links.

Closes #146