### PR TITLE
Add luarocks as additional installed tool

### DIFF
--- a/dockerfiles/alpine_3.5_1.10.3
+++ b/dockerfiles/alpine_3.5_1.10.3
@@ -11,10 +11,12 @@ RUN addgroup -S tarantool \
 ARG TNT_VER
 ENV TARANTOOL_VERSION=${TNT_VER} \
     TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
+    TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
     CURL_REPO=https://github.com/curl/curl.git \
     CURL_TAG=curl-7_59_0 \
     GPERFTOOLS_REPO=https://github.com/gperftools/gperftools.git \
     GPERFTOOLS_TAG=gperftools-2.5 \
+    LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \
     LUAROCK_VSHARD_VERSION=0.1.14 \
     LUAROCK_AVRO_SCHEMA_VERSION=3.0.3 \
     LUAROCK_EXPERATIOND_VERSION=1.0.1 \
@@ -60,6 +62,7 @@ RUN set -x \
         lz4-dev \
         binutils-dev \
         ncurses-dev \
+        lua-dev \
         musl-dev \
         make \
         git \
@@ -107,11 +110,22 @@ RUN set -x \
     && make -C /usr/src/tarantool -j\
     && make -C /usr/src/tarantool install \
     && make -C /usr/src/tarantool clean \
+    && : "---------- luarocks ----------" \
+    && wget -O luarocks.tar.gz "$LUAROCKS_URL" \
+    && mkdir -p /usr/src/luarocks \
+    && tar -xzf luarocks.tar.gz -C /usr/src/luarocks --strip-components=1 \
+    && (cd /usr/src/luarocks; \
+        ./configure; \
+        make -j build; \
+        make install) \
+    && rm -r /usr/src/luarocks \
     && rm -rf /usr/src/tarantool \
     && rm -rf /usr/src/gperftools \
     && rm -rf /usr/src/go \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
+
+COPY files/luarocks-config.lua /usr/local/etc/luarocks/config-5.1.lua
 
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
@@ -128,6 +142,7 @@ RUN set -x \
         gcc \
         g++ \
         postgresql-dev \
+        lua-dev \
         musl-dev \
         cyrus-sasl-dev \
         mosquitto-dev \

--- a/dockerfiles/alpine_3.5_1.x
+++ b/dockerfiles/alpine_3.5_1.x
@@ -14,6 +14,7 @@ ENV TARANTOOL_VERSION=${TNT_VER} \
     TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
     GPERFTOOLS_REPO=https://github.com/gperftools/gperftools.git \
     GPERFTOOLS_TAG=gperftools-2.5 \
+    LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \
     LUAROCK_VSHARD_VERSION=0.1.14 \
     LUAROCK_AVRO_SCHEMA_VERSION=3.0.3 \
     LUAROCK_EXPERATIOND_VERSION=1.0.1 \

--- a/dockerfiles/alpine_3.5_2.2
+++ b/dockerfiles/alpine_3.5_2.2
@@ -11,10 +11,12 @@ RUN addgroup -S tarantool \
 ARG TNT_VER
 ENV TARANTOOL_VERSION=${TNT_VER} \
     TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
+    TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
     CURL_REPO=https://github.com/curl/curl.git \
     CURL_TAG=curl-7_59_0 \
     GPERFTOOLS_REPO=https://github.com/gperftools/gperftools.git \
     GPERFTOOLS_TAG=gperftools-2.5 \
+    LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \
     LUAROCK_VSHARD_VERSION=0.1.14 \
     LUAROCK_AVRO_SCHEMA_VERSION=3.0.3 \
     LUAROCK_EXPERATIOND_VERSION=1.0.1 \
@@ -61,6 +63,7 @@ RUN set -x \
         zlib-dev \
         binutils-dev \
         ncurses-dev \
+        lua-dev \
         musl-dev \
         make \
         git \
@@ -109,11 +112,22 @@ RUN set -x \
     && make -C /usr/src/tarantool -j\
     && make -C /usr/src/tarantool install \
     && make -C /usr/src/tarantool clean \
+    && : "---------- luarocks ----------" \
+    && wget -O luarocks.tar.gz "$LUAROCKS_URL" \
+    && mkdir -p /usr/src/luarocks \
+    && tar -xzf luarocks.tar.gz -C /usr/src/luarocks --strip-components=1 \
+    && (cd /usr/src/luarocks; \
+        ./configure; \
+        make -j build; \
+        make install) \
+    && rm -r /usr/src/luarocks \
     && rm -rf /usr/src/tarantool \
     && rm -rf /usr/src/gperftools \
     && rm -rf /usr/src/go \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
+
+COPY files/luarocks-config.lua /usr/local/etc/luarocks/config-5.1.lua
 
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
@@ -130,6 +144,7 @@ RUN set -x \
         gcc \
         g++ \
         postgresql-dev \
+        lua-dev \
         musl-dev \
         cyrus-sasl-dev \
         mosquitto-dev \

--- a/dockerfiles/alpine_3.5_2.x
+++ b/dockerfiles/alpine_3.5_2.x
@@ -11,8 +11,10 @@ RUN addgroup -S tarantool \
 ARG TNT_VER
 ENV TARANTOOL_VERSION=${TNT_VER} \
     TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
+    TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
     GPERFTOOLS_REPO=https://github.com/gperftools/gperftools.git \
     GPERFTOOLS_TAG=gperftools-2.5 \
+    LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \
     LUAROCK_VSHARD_VERSION=0.1.14 \
     LUAROCK_AVRO_SCHEMA_VERSION=3.0.3 \
     LUAROCK_EXPERATIOND_VERSION=1.0.1 \
@@ -59,6 +61,7 @@ RUN set -x \
         zlib-dev \
         binutils-dev \
         ncurses-dev \
+        lua-dev \
         musl-dev \
         make \
         git \
@@ -100,11 +103,22 @@ RUN set -x \
     && make -C /usr/src/tarantool -j\
     && make -C /usr/src/tarantool install \
     && make -C /usr/src/tarantool clean \
+    && : "---------- luarocks ----------" \
+    && wget -O luarocks.tar.gz "$LUAROCKS_URL" \
+    && mkdir -p /usr/src/luarocks \
+    && tar -xzf luarocks.tar.gz -C /usr/src/luarocks --strip-components=1 \
+    && (cd /usr/src/luarocks; \
+        ./configure; \
+        make -j build; \
+        make install) \
+    && rm -r /usr/src/luarocks \
     && rm -rf /usr/src/tarantool \
     && rm -rf /usr/src/gperftools \
     && rm -rf /usr/src/go \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
+
+COPY files/luarocks-config.lua /usr/local/etc/luarocks/config-5.1.lua
 
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
@@ -121,6 +135,7 @@ RUN set -x \
         gcc \
         g++ \
         postgresql-dev \
+        lua-dev \
         musl-dev \
         cyrus-sasl-dev \
         mosquitto-dev \

--- a/dockerfiles/centos_7_1.x
+++ b/dockerfiles/centos_7_1.x
@@ -10,6 +10,8 @@ RUN groupadd tarantool \
 ARG TNT_VER
 ENV TARANTOOL_VERSION=${TNT_VER} \
     TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
+    TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
+    LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \
     LUAROCK_VSHARD_VERSION=0.1.14 \
     LUAROCK_CHECKS_VERSION=3.0.1 \
     LUAROCK_AVRO_SCHEMA_VERSION=3.0.3 \
@@ -58,6 +60,7 @@ RUN set -x \
         lz4-devel \
         binutils-devel \
         ncurses-devel \
+        lua-devel \
         make \
         git \
         libunwind-devel \
@@ -96,6 +99,15 @@ RUN set -x \
     && make -C /usr/src/tarantool -j\
     && make -C /usr/src/tarantool install \
     && make -C /usr/src/tarantool clean \
+    && : "---------- luarocks ----------" \
+    && wget -O luarocks.tar.gz "$LUAROCKS_URL" \
+    && mkdir -p /usr/src/luarocks \
+    && tar -xzf luarocks.tar.gz -C /usr/src/luarocks --strip-components=1 \
+    && (cd /usr/src/luarocks; \
+        ./configure; \
+        make -j build; \
+        make install) \
+    && rm -r /usr/src/luarocks \
     && rm -rf /usr/src/tarantool \
     && rm -rf /usr/src/go \
     && rm -rf /usr/src/icu \
@@ -126,6 +138,8 @@ RUN set -x \
         golang-src \
     && rpm -qa | grep devel | xargs yum -y remove \
     && rm -rf /var/cache/yum
+
+COPY files/luarocks-config_centos.lua /usr/local/etc/luarocks/config-5.1.lua
 
 RUN set -x \
     && yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \

--- a/files/luarocks-config_centos.lua
+++ b/files/luarocks-config_centos.lua
@@ -1,0 +1,11 @@
+rocks_trees = {
+   { name = [[user]], root = home..[[/.luarocks]] },
+   { name = [[system]], root = [[/usr/local]] }
+}
+
+lib_modules_path="/lib64/lua/"..lua_version
+
+rocks_servers = {
+    [[http://rocks.tarantool.org/]],
+    [[http://luarocks.org/repositories/rocks]]
+}


### PR DESCRIPTION
Luarocks tool was removed in commit:
(d68c646cc437e2bf4a861285dded166f33f3cb2a "penlight package dependencies broken")

Luarocks tool was used before for installing packages.
After mentioned commit luarocks tool changed to tarantoolctl
and due to no need in it was in the build it was completely
removed from installation build of the images. For now found
that some users still need it. It was decided to return
luarocks tool installed in the image, but not to use it for
packages installations in images builds.

Follows up #140