### PR TITLE
gitlab-ci: make all build jobs interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ before_script:
   stage: build
   tags:
     - deploy_test
+  interruptible: true
   script:
     - >
       if  [ ${CI_COMMIT_REF_NAME} = master ] || \


### PR DESCRIPTION
Set for all jobs interruptible flag to be able to reset
duplicating jobs in the gitlab-ci testing queue.

Closes #171