### PR TITLE
Change the dockerfile for Tarantool 2.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,7 +162,7 @@ before_script:
     DIST: '3.9'
     TAG: '2.1'
     VER: '2.1'
-    DOCKERFILE_NAME_SUFFIX: '2.2'
+    DOCKERFILE_NAME_SUFFIX: '1.x'
     PORT: 5210
 
 # Tarantool branch 2.2

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Rolling versions:
 | Docker tag | Dockerfile                |
 | ---------- | ------------------------- |
 | 1          | dockerfile/alpine_3.9_1.x |
-| 2.1        | dockerfile/alpine_3.9_2.2 |
+| 2.1        | dockerfile/alpine_3.9_1.x |
 | 2.2        | dockerfile/alpine_3.9_2.x |
 | 2.3        | dockerfile/alpine_3.9_2.x |
 | 2.4        | dockerfile/alpine_3.9_2.x |


### PR DESCRIPTION
During bumping alpine from 3.5 to 3.9 at commit:
  aef661e81bc8e7c26f4ac6f516d83a69204653b3 "Bump alpine images version"
    
Found that Tarantool 2.1 branch with version equal and later than 2.1.3
tag didn't build on alpine 3.5 with both dockerfiles available for it,
due to issue:
```
    /usr/src/tarantool/third_party/curl/lib/vtls/openssl.c: In function 'set_ssl_version_min_max':
    /usr/src/tarantool/third_party/curl/lib/vtls/openssl.c:2195:9: error: implicit declaration of function 'SSL_CTX_set_min_proto_version' [-Werror=implicit-function-declaration]
         if(!SSL_CTX_set_min_proto_version(ctx, ossl_ssl_version_min)) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/src/tarantool/third_party/curl/lib/vtls/openssl.c:2231:7: error: implicit declaration of function 'SSL_CTX_set_max_proto_version' [-Werror=implicit-function-declaration]
       if(!SSL_CTX_set_max_proto_version(ctx, ossl_ssl_version_max)) {
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/src/tarantool/third_party/curl/lib/url.c: In function 'Curl_connect':
    /usr/src/tarantool/third_party/curl/lib/url.c:1876:13: warning: offset outside bounds of constant string
         hostname++;
         ~~~~~~~~^~
    cc1: some warnings being treated as errors
```

The issue occurred because of the unsupported openssl version, please check [1].
These macros are only available in OpenSSL 1.1.0. While alpine versions uses different openssl versions:
Alpine 3.5: openssl (1.0.2q-r0)
Alpine 3.9: openssl (1.1.1g-r0)

Also in #152 the alpine version was bumped and current change of the
build job for Tarantool 2.1 to use alpine 3.9 resolved the issue.
    
Currently found that on alpine 3.9 it successfully built, but only
with *1.x dockerfile, due to tarantoolctl tool failed installing rocks
at *2.x file.
    
So decided to use for Tarantool 2.1 -> alpine_3.9_1.x dockerfile.
    
Closes #173
Follows up #152

[1] - https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_max_proto_version.html

