### PR TITLE
Add ldoc luarocks to all the dockerfiles in common

### DIFF
--- a/dockerfiles/alpine_3.5_1.x
+++ b/dockerfiles/alpine_3.5_1.x
@@ -142,7 +142,11 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+RUN mkdir -p /usr/local/etc/luarocks \
+    && mkdir -p /usr/local/etc/tarantool/rocks
+
 COPY files/luarocks-config.lua /usr/local/etc/luarocks/config-5.1.lua
+COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
@@ -189,6 +193,8 @@ RUN set -x \
     && rm -rf /geos.tar.bz2 \
     && : "---------- luarocks ----------" \
     && cd / \
+    && : "ldoc" \
+    && tarantoolctl rocks install ldoc \
     && : "lua-term" \
     && tarantoolctl rocks install lua-term \
     && : "avro" \

--- a/dockerfiles/alpine_3.5_2.x
+++ b/dockerfiles/alpine_3.5_2.x
@@ -144,7 +144,11 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+RUN mkdir -p /usr/local/etc/luarocks \
+    && mkdir -p /usr/local/etc/tarantool/rocks
+
 COPY files/luarocks-config.lua /usr/local/etc/luarocks/config-5.1.lua
+COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
@@ -194,7 +198,7 @@ RUN set -x \
     && : "---------- luarocks ----------" \
     && cd / \
     && : "ldoc" \
-    && tarantoolctl rocks install ldoc --server=http://rocks.moonscript.org \
+    && tarantoolctl rocks install ldoc \
     && : "lua-term" \
     && tarantoolctl rocks install lua-term \
     && : "avro" \

--- a/dockerfiles/alpine_3.9_1.x
+++ b/dockerfiles/alpine_3.9_1.x
@@ -136,7 +136,11 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+RUN mkdir -p /usr/local/etc/luarocks \
+    && mkdir -p /usr/local/etc/tarantool/rocks
+
 COPY files/luarocks-config.lua /usr/local/etc/luarocks/config-5.1.lua
+COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
@@ -183,8 +187,10 @@ RUN set -x \
     && rm -rf /usr/src/geos \
     && rm -rf /geos.tar.bz2 \
     && : "---------- luarocks ----------" \
-    && luarocks install lua-term \
+    && : "ldoc" \
     && luarocks install ldoc \
+    && : "lua-term" \
+    && luarocks install lua-term \
     && : "avro" \
     && luarocks install avro-schema $LUAROCK_AVRO_SCHEMA_VERSION \
     && : "expirationd" \

--- a/dockerfiles/alpine_3.9_2.x
+++ b/dockerfiles/alpine_3.9_2.x
@@ -135,7 +135,11 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+RUN mkdir -p /usr/local/etc/luarocks \
+    && mkdir -p /usr/local/etc/tarantool/rocks
+
 COPY files/luarocks-config.lua /usr/local/etc/luarocks/config-5.1.lua
+COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
@@ -185,7 +189,7 @@ RUN set -x \
     && : "---------- luarocks ----------" \
     && cd / \
     && : "ldoc" \
-    && tarantoolctl rocks install ldoc --server=http://rocks.moonscript.org \
+    && tarantoolctl rocks install ldoc \
     && : "lua-term" \
     && tarantoolctl rocks install lua-term \
     && : "avro" \

--- a/dockerfiles/centos_7_1.x
+++ b/dockerfiles/centos_7_1.x
@@ -140,7 +140,11 @@ RUN set -x \
     && rpm -qa | grep devel | xargs yum -y remove \
     && rm -rf /var/cache/yum
 
+RUN mkdir -p /usr/local/etc/luarocks \
+    && mkdir -p /usr/local/etc/tarantool/rocks
+
 COPY files/luarocks-config_centos.lua /usr/local/etc/luarocks/config-5.1.lua
+COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 
 RUN set -x \
     && yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
@@ -170,7 +174,7 @@ RUN set -x \
     && : "lua-term" \
     && tarantoolctl rocks install lua-term \
     && : "ldoc" \
-    && tarantoolctl rocks install ldoc --server=http://rocks.moonscript.org \
+    && tarantoolctl rocks install ldoc \
     && : "vshard" \
     && tarantoolctl rocks install vshard $LUAROCK_VSHARD_VERSION \
     && : "checks" \

--- a/dockerfiles/centos_7_2.x
+++ b/dockerfiles/centos_7_2.x
@@ -136,7 +136,11 @@ RUN set -x \
     && rpm -qa | grep devel | xargs yum -y remove \
     && rm -rf /var/cache/yum
 
+RUN mkdir -p /usr/local/etc/luarocks \
+    && mkdir -p /usr/local/etc/tarantool/rocks
+
 COPY files/luarocks-config_centos.lua /usr/local/etc/luarocks/config-5.1.lua
+COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 
 RUN set -x \
     && yum -y install https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
@@ -166,7 +170,7 @@ RUN set -x \
     && : "lua-term" \
     && tarantoolctl rocks install lua-term \
     && : "ldoc" \
-    && tarantoolctl rocks install ldoc --server=http://rocks.moonscript.org \
+    && tarantoolctl rocks install ldoc \
     && : "vshard" \
     && tarantoolctl rocks install vshard $LUAROCK_VSHARD_VERSION \
     && : "checks" \


### PR DESCRIPTION
    Add ldoc luarocks to all the dockerfiles in common
    
    Found that ldoc rock installation fails using tarantoolctl without
    additional setup of tarantoolctl configuration file and without
    server path in options. In this case ldoc rock couldn't be found.
    To avoid of it in past additional server path was set, but in real
    the configuration file for tarantoolctl had to be installed as:
    
      /usr/local/etc/tarantool/rocks/config-5.1.lua
    
    It was missed in commit:
    
      d68c646cc437e2bf4a861285dded166f33f3cb2a "penlight package dependencies broken"
    
    Found that tarantoolctl didn't fail with the other rocks installations,
    because it had its rocks in server path 'http://rocks.tarantool.org',
    which is default for tarantoolctl tool even without additional
    configurating, while ldoc didn't have any rock there.
    
    To fix ldoc rock installation using tarantoolctl the configuration
    file created and removed not needed for now additional server path
    setup from tarantoolctl call options.
    
    For CentOS 7 based images configuration file was used without setup
    'lib_modules_path' variable to be sure that libs will be created in
    both paths:
    
      /opt/tarantool/.rocks/lib/
      /opt/tarantool/.rocks/lib64/
    
    Closes #175
