### PR TITLE
Fix luarocks installation functionality

### DIFF
--- a/dockerfiles/alpine_3.5_1.x
+++ b/dockerfiles/alpine_3.5_1.x
@@ -224,6 +224,10 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+# gh-170: needed for luarocks
+RUN apk update \
+    && apk add wget git
+
 RUN mkdir -p /var/lib/tarantool \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /opt/tarantool \

--- a/dockerfiles/alpine_3.5_2.x
+++ b/dockerfiles/alpine_3.5_2.x
@@ -228,6 +228,10 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+# gh-170: needed for luarocks
+RUN apk update \
+    && apk add wget git
+
 RUN mkdir -p /var/lib/tarantool \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /opt/tarantool \

--- a/dockerfiles/alpine_3.9_1.x
+++ b/dockerfiles/alpine_3.9_1.x
@@ -216,6 +216,10 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+# gh-170: needed for luarocks
+RUN apk update \
+    && apk add wget git
+
 RUN mkdir -p /var/lib/tarantool \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /opt/tarantool \

--- a/dockerfiles/alpine_3.9_2.x
+++ b/dockerfiles/alpine_3.9_2.x
@@ -219,6 +219,10 @@ RUN set -x \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 
+# gh-170: needed for luarocks
+RUN apk update \
+    && apk add wget git
+
 RUN mkdir -p /var/lib/tarantool \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /opt/tarantool \


### PR DESCRIPTION
Alpine 3.5/3.9 had internal wget tool based on it's busybox. Found that
it was not workable with luacheck tool. The current fix changes wget
tool from busybox to wget from package. To install wget from the
package added git package installation. Also repository update added.

Closes #170