### PR TITLE
Add ldecnumber installation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,7 @@ before_script:
     VER: '1.10.0'
     PORT: 5101
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.5 1.10.1':
   <<: *build_definition
@@ -52,6 +53,7 @@ before_script:
     VER: '1.10.1'
     PORT: 5101
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.5 1.10.2':
   <<: *build_definition
@@ -62,6 +64,7 @@ before_script:
     VER: '1.10.2'
     PORT: 5102
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.5 1.10.3':
   <<: *build_definition
@@ -72,6 +75,7 @@ before_script:
     VER: '1.10.3'
     PORT: 5103
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.9 1.10.4':
   <<: *build_definition
@@ -83,6 +87,7 @@ before_script:
     PORT: 5104
     ROCKS_INSTALLER: 'luarocks'
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.9 1.10.5':
   <<: *build_definition
@@ -94,6 +99,7 @@ before_script:
     PORT: 5105
     ROCKS_INSTALLER: 'luarocks'
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.9 1.10.6':
   <<: *build_definition
@@ -105,6 +111,7 @@ before_script:
     PORT: 5106
     ROCKS_INSTALLER: 'luarocks'
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.9 1.10.7':
   <<: *build_definition
@@ -115,6 +122,7 @@ before_script:
     VER: '1.10.7'
     PORT: 5107
     ROCKS_INSTALLER: 'luarocks'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.9 1.x':
   <<: *build_definition
@@ -125,6 +133,7 @@ before_script:
     VER: '1.x'
     PORT: 5100
     ROCKS_INSTALLER: 'luarocks'
+    INSTALL_LDECNUMBER: 'ON'
 
 # Tarantool branch 2.1
 
@@ -137,6 +146,7 @@ before_script:
     VER: '2.1.0'
     PORT: 5211
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.5 2.1.1':
   <<: *build_definition
@@ -147,6 +157,7 @@ before_script:
     VER: '2.1.1'
     PORT: 5211
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.5 2.1.2':
   <<: *build_definition
@@ -157,6 +168,7 @@ before_script:
     VER: '2.1.2'
     PORT: 5212
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.9 2.1.3':
   <<: *build_definition
@@ -168,6 +180,7 @@ before_script:
     PORT: 5213
     ROCKS_INSTALLER: 'luarocks'
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.9 2.1':
   <<: *build_definition
@@ -179,6 +192,7 @@ before_script:
     PORT: 5210
     ROCKS_INSTALLER: 'luarocks'
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 # Tarantool branch 2.2
 
@@ -191,6 +205,7 @@ before_script:
     VER: '2.2.0'
     PORT: 5220
     ENABLE_BUNDLED_LIBYAML: 'OFF'
+    INSTALL_LDECNUMBER: 'ON'
 
 'alpine 3.5 2.2.1':
   <<: *build_definition

--- a/.gitlab.mk
+++ b/.gitlab.mk
@@ -10,6 +10,7 @@ build:
 	docker build --no-cache --network=host \
 		--build-arg ROCKS_INSTALLER=${ROCKS_INSTALLER} \
 		--build-arg ENABLE_BUNDLED_LIBYAML=${ENABLE_BUNDLED_LIBYAML} \
+		--build-arg INSTALL_LDECNUMBER=${INSTALL_LDECNUMBER} \
 		--build-arg TNT_VER=${TNT_VER} \
 		--build-arg BASE_IMAGE="${OS}:${DIST}" \
 		-t ${IMAGE}:${TAG} -f dockerfiles/${OS}_${DIST}$${DOCKERFILE_SUFFIX} .

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ is only one Tarantool instance running in the container.
 - [mqtt](https://github.com/tarantool/mqtt): Client for MQTT message brokers
 - [gis](https://github.com/tarantool/gis): store and query geospatial data
 - [gperftools](https://github.com/tarantool/gperftools): collect CPU profile to find bottlenecks in your code
+- [ldecnumber](https://github.com/tarantool/ldecnumber): decimal arithmetic package
 
 If the module you need is not listed here, there is a good chance we may add it. Open an issue [on our GitHub](https://github.com/tarantool/docker).
 

--- a/dockerfiles/alpine_3.5
+++ b/dockerfiles/alpine_3.5
@@ -31,7 +31,8 @@ ENV TARANTOOL_VERSION=${TNT_VER} \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
-    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
+    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1 \
+    LDECNUMBER_ROCKSPEC=https://raw.githubusercontent.com/tarantool/ldecnumber/master/ldecnumber-scm-1.rockspec
 
 COPY files/gperftools_alpine.diff /
 
@@ -229,7 +230,17 @@ RUN set -x \
     && : "gis" \
     && ${ROCKS_INSTALLER} install gis $LUAROCK_TARANTOOL_GIS_VERSION \
     && : "gperftools" \
-    && ${ROCKS_INSTALLER} install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION \
+    && ${ROCKS_INSTALLER} install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION
+
+ARG INSTALL_LDECNUMBER
+RUN set -x ; \
+    if [ "${INSTALL_LDECNUMBER}" == "ON" ]; then \
+        cd / \
+        && : "ldecnumber" \
+        && ${ROCKS_INSTALLER} install $LDECNUMBER_ROCKSPEC ; \
+    fi
+
+RUN cd / \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 

--- a/dockerfiles/alpine_3.9
+++ b/dockerfiles/alpine_3.9
@@ -29,7 +29,8 @@ ENV TARANTOOL_VERSION=${TNT_VER} \
     LUAROCK_TARANTOOL_MQTT_VERSION=1.2.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
-    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
+    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1 \
+    LDECNUMBER_ROCKSPEC=https://raw.githubusercontent.com/tarantool/ldecnumber/master/ldecnumber-scm-1.rockspec
 
 COPY files/gperftools_alpine.diff /
 
@@ -220,7 +221,17 @@ RUN set -x \
     && : "gis" \
     && ${ROCKS_INSTALLER} install gis $LUAROCK_TARANTOOL_GIS_VERSION \
     && : "gperftools" \
-    && ${ROCKS_INSTALLER} install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION \
+    && ${ROCKS_INSTALLER} install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION
+
+ARG INSTALL_LDECNUMBER
+RUN set -x ; \
+    if [ "${INSTALL_LDECNUMBER}" == "ON" ]; then \
+        cd / \
+        && : "ldecnumber" \
+        && ${ROCKS_INSTALLER} install $LDECNUMBER_ROCKSPEC ; \
+    fi
+
+RUN cd / \
     && : "---------- remove build deps ----------" \
     && apk del .build-deps
 

--- a/dockerfiles/centos_7
+++ b/dockerfiles/centos_7
@@ -26,7 +26,8 @@ ENV TARANTOOL_VERSION=${TNT_VER} \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
-    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
+    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1 \
+    LDECNUMBER_ROCKSPEC=https://raw.githubusercontent.com/tarantool/ldecnumber/master/ldecnumber-scm-1.rockspec
 
 RUN yum -y install epel-release && \
     yum -y update && \
@@ -195,9 +196,19 @@ RUN set -x \
     && : "gis" \
     && tarantoolctl rocks install gis $LUAROCK_TARANTOOL_GIS_VERSION \
     && : "gperftools" \
-    && tarantoolctl rocks install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION \
+    && tarantoolctl rocks install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION
+
+ARG INSTALL_LDECNUMBER
+RUN set -x ; \
+    if [ "${INSTALL_LDECNUMBER}" == "ON" ]; then \
+        cd / \
+        && : "ldecnumber" \
+        && ${ROCKS_INSTALLER} install $LDECNUMBER_ROCKSPEC ; \
+    fi
+
+RUN cd / \
     && : "---------- remove build deps ----------" \
-    && rm -rf /rocks \
+    && apk del .build-deps \
     && yum -y remove \
         git \
         cmake \
@@ -215,7 +226,6 @@ RUN set -x \
         golang-src \
     && rpm -qa | grep devel | xargs yum -y remove \
     && rm -rf /var/cache/yum
-
 
 RUN set -x \
     && : "---------- gosu ----------" \


### PR DESCRIPTION
Current PR based on https://github.com/tarantool/docker/pull/109

According to PR-109 [1] it was decided to add ldecnumber installation.
Depending that 2.x images are lack of decimals support for now checked
Tarantool releases and tags that need to be updated with it. Found that
Tarantool since 2.2 release branches and 2.2.1 release tags are lack of
it, than ldecnumber number installation was added to the earlier tags
and release branches.

Closes #77
Closes #112

[1] - https://github.com/tarantool/docker/pull/109

Co-authored-by: Alexander V. Tikhonov <avtikhon@tarantool.org>