### PR TITLE
Fix mariadb-client-libs installation on alpine 3.9

### DIFF
--- a/dockerfiles/alpine_3.9
+++ b/dockerfiles/alpine_3.9
@@ -145,7 +145,7 @@ COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 ARG ROCKS_INSTALLER
 RUN set -x \
     && apk add --no-cache --virtual .run-deps \
-        mariadb-client-libs \
+        mariadb-connector-c-dev \
         libpq \
         cyrus-sasl \
         mosquitto-libs \


### PR DESCRIPTION
Found that since alpine 3.8 the package mariadb-client-libs was
changed to mariadb-connector-c-dev, check [1], [2].

[1] - https://github.com/docker-in-aws/docker-in-aws/issues/1
[2] - https://pkgs.alpinelinux.org/contents?file=libmysqlclient.so*&path=&name=&branch=v3.9&repo=main&arch=x86_64