### PR TITLE
Update the version for mqtt module

### DIFF
--- a/dockerfiles/alpine_3.9
+++ b/dockerfiles/alpine_3.9
@@ -27,7 +27,7 @@ ENV TARANTOOL_VERSION=${TNT_VER} \
     LUAROCK_METRICS_VERSION=0.12.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.2 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
-    LUAROCK_TARANTOOL_MQTT_VERSION=1.5.0 \
+    LUAROCK_TARANTOOL_MQTT_VERSION=1.5.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
     LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
@@ -149,7 +149,6 @@ RUN set -x \
         mariadb-connector-c-dev \
         libpq \
         cyrus-sasl \
-        mosquitto-libs \
         libev \
     && apk add --no-cache --virtual .build-deps.2 \
         git \
@@ -162,7 +161,6 @@ RUN set -x \
         lua-dev \
         musl-dev \
         cyrus-sasl-dev \
-        mosquitto-dev \
         libev-dev \
         wget \
         unzip \


### PR DESCRIPTION
Update the version for mqtt module

This patch updates the version for mqtt module to the latest tag and
removes the steps with installing the mosquitto library for alpine:3.9.
With the new release of mqtt module, libmosquitto builds statically
when the module is installed from luarocks. That fix eliminates the
dependencies that are not necessary anymore.

Closes tarantool/mqtt#41