### PR TITLE
Artembo/add ubuntu centos

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,12 @@ Rolling versions:
 
 Special builds:
 
-| Docker tag  | Dockerfile          |
-| ----------- | ------------------- |
-| 1.x-centos7 | dockerfile/centos_7 |
-| 2.x-centos7 | dockerfile/centos_7 |
+| Docker tag        | Dockerfile              |
+| ----------------- | ----------------------- |
+| 2.10.0-centos7    | dockerfile/centos_7     |
+| 2.10.0-ubuntu     | dockerfile/ubuntu_20.04 |
+| 1.x-centos7       | dockerfile/centos_7     |
+| 2.x-centos7       | dockerfile/centos_7     |
 
 ## Release policy
 

--- a/dockerfiles/alpine_3.15
+++ b/dockerfiles/alpine_3.15
@@ -203,6 +203,8 @@ RUN set -x \
     && ${ROCKS_INSTALLER} install http $LUAROCK_HTTP_VERSION \
     && : "pg" \
     && ${ROCKS_INSTALLER} install pg $LUAROCK_TARANTOOL_PG_VERSION \
+    && : "mysql" \
+    && ${ROCKS_INSTALLER} install mysql $LUAROCK_TARANTOOL_MYSQL_VERSION \
     && : "memcached" \
     && ${ROCKS_INSTALLER} install memcached $LUAROCK_MEMCACHED_VERSION \
     && : "metrics" \

--- a/dockerfiles/centos_7
+++ b/dockerfiles/centos_7
@@ -1,18 +1,12 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
-MAINTAINER mail@racktear.com
+FROM ${BASE_IMAGE}centos:7
+LABEL org.opencontainers.image.authors="artembo@me.com; piligrim@rootnix.net"
 
-RUN groupadd tarantool \
-    && adduser -g tarantool tarantool
+ARG TNT_VER \
+    GC64
 
-# An ARG instruction goes out of scope at the end of the build
-# stage where it was defined. To use an arg in multiple stages,
-# each stage must include the ARG instruction
-ARG TNT_VER
-ENV TARANTOOL_VERSION=${TNT_VER} \
-    TARANTOOL_DOWNLOAD_URL=https://github.com/tarantool/tarantool.git \
-    TARANTOOL_INSTALL_LUADIR=/usr/local/share/tarantool \
-    LUAROCKS_URL=https://github.com/tarantool/luarocks/archive/6e6fe62d9409fe2103c0fd091cccb3da0451faf5.tar.gz \
+ENV GC64=${GC64:-false} \
+    TARANTOOL_INSTALLER_URL=https://www.tarantool.io/release/${TNT_VER:-2}/installer.sh \
     LUAROCK_VSHARD_VERSION=0.1.18 \
     LUAROCK_AVRO_SCHEMA_VERSION=3.0.6 \
     LUAROCK_EXPERATIOND_VERSION=1.1.1 \
@@ -22,125 +16,31 @@ ENV TARANTOOL_VERSION=${TNT_VER} \
     LUAROCK_MEMCACHED_VERSION=1.0.1 \
     LUAROCK_METRICS_VERSION=0.12.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.2 \
-    LUAROCK_TARANTOOL_MYSQL_VERSION=2.0.1 \
+    LUAROCK_TARANTOOL_MYSQL_VERSION=2.1.0 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
     LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
 
-RUN yum -y install epel-release && \
-    yum -y update && \
-    yum -y clean all
-
-RUN set -x \
-    && yum -y install \
-        libstdc++ \
-        readline \
-        openssl \
-        lz4 \
-        binutils \
-        ncurses \
-        libgomp \
-        lua \
-        tar \
-        zip \
-        zlib \
-        unzip \
-        libunwind \
-        ca-certificates \
-    && yum -y install \
-        file \
-        gcc-c++ \
-        cmake3 \
-        readline-devel \
-        openssl-devel \
-        zlib-devel \
-        lz4-devel \
-        binutils-devel \
-        ncurses-devel \
-        lua-devel \
-        make \
-        git \
-        libunwind-devel \
-        autoconf \
-        automake \
-        libtool \
-        go \
-        wget \
-    && : "---------- libicu ----------" \
-    && wget https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz \
-    && mkdir -p /usr/src/icu \
-        && tar -xzf icu4c-65_1-src.tgz -C /usr/src/icu --strip-components=1 \
-        && rm icu4c-65_1-src.tgz \
-    && (cd /usr/src/icu/source; \
-        chmod +x runConfigureICU configure install-sh; \
-        ./runConfigureICU Linux/gcc; \
-        make -j ; \
-        make install; \
-        echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf; \
-        ldconfig ) \
-    && : "---------- gperftools ----------" \
-    && yum install -y gperftools-libs \
-    && (GOPATH=/usr/src/go go get github.com/google/pprof; \
-        cp /usr/src/go/bin/pprof /usr/local/bin) \
-    && : "---------- tarantool ----------" \
-    && mkdir -p /usr/src/tarantool \
-    && git clone "$TARANTOOL_DOWNLOAD_URL" /usr/src/tarantool \
-    && (cd /usr/src/tarantool; git checkout "$TARANTOOL_VERSION";) \
-    && (cd /usr/src/tarantool; git submodule update --init --recursive;) \
-    && (cd /usr/src/tarantool; \
-       cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo\
-             -DENABLE_BUNDLED_LIBYAML:BOOL=ON\
-             -DENABLE_BACKTRACE:BOOL=ON\
-             -DENABLE_DIST:BOOL=ON\
-             .) \
-    && make -C /usr/src/tarantool -j\
-    && make -C /usr/src/tarantool install \
-    && make -C /usr/src/tarantool clean \
-    && : "---------- luarocks ----------" \
-    && wget -O luarocks.tar.gz "$LUAROCKS_URL" \
-    && mkdir -p /usr/src/luarocks \
-    && tar -xzf luarocks.tar.gz -C /usr/src/luarocks --strip-components=1 \
-    && (cd /usr/src/luarocks; \
-        ./configure; \
-        make -j build; \
-        make install) \
-    && rm -r /usr/src/luarocks \
-    && rm -rf /usr/src/tarantool \
-    && rm -rf /usr/src/go \
-    && rm -rf /usr/src/icu \
-    && : "---------- remove build deps ----------" \
-    && yum -y remove \
-        file \
-        gcc-c++ \
-        cmake3 \
-        readline-devel \
-        openssl-devel \
-        lz4-devel \
-        zlib-devel \
-        binutils-devel \
-        ncurses-devel \
-        make \
-        git \
-        libunwind-devel \
-        autoconf \
-        automake \
-        libtool \
-        go \
-        wget \
-        kernel-headers \
-        golang-src \
-    && rpm -qa | grep devel | xargs yum -y remove \
-    && rm -rf /var/cache/yum
-
-RUN mkdir -p /usr/local/etc/luarocks \
-    && mkdir -p /usr/local/etc/tarantool/rocks
-
 COPY files/luarocks-config_centos.lua /usr/local/etc/luarocks/config-5.1.lua
 COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
 
-RUN set -x \
-    && yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-    && yum -y install \
+# Set yum repository for Postgresql 9.6 since this version
+# has been removed from pgdg repository.
+RUN echo $'[pg]\n\
+name=PostgreSQL 9.6 RHEL/CentOS $releasever - $basearch\n\
+baseurl=https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-$basearch\n\
+enabled=1\n\
+gpgcheck=1\n\
+gpgkey=https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96\n\
+repo_gpgcheck = 1\n'\
+>> /etc/yum.repos.d/pg.repo \
+    && groupadd tarantool \
+    && adduser -g tarantool tarantool \
+    && curl $TARANTOOL_INSTALLER_URL | bash \
+    && : "---------- tarantool ----------" \
+    && yum install -y  \
+        tarantool \
+        tarantool-devel \
         mariadb-libs \
         postgresql96-libs \
         cyrus-sasl \
@@ -149,7 +49,7 @@ RUN set -x \
         geos \
         unzip \
         openssl-libs \
-    && yum -y install \
+        luarocks \
         git \
         cmake \
         make \
@@ -161,49 +61,30 @@ RUN set -x \
         proj-devel \
         geos-devel \
         openssl-devel \
+        gperftools-libs \
+    && ln -s /usr/lib64/libprofiler.so.0 /usr/lib64/libprofiler.so \
     && mkdir -p /rocks \
-    && : "---------- luarocks ----------" \
-    && : "lua-term" \
     && tarantoolctl rocks install lua-term \
-    && : "ldoc" \
-    && tarantoolctl rocks install ldoc \
-    && : "vshard" \
     && tarantoolctl rocks install vshard $LUAROCK_VSHARD_VERSION \
-    && : "checks" \
     && tarantoolctl rocks install checks $LUAROCK_CHECKS_VERSION \
-    && : "avro" \
     && tarantoolctl rocks install avro-schema $LUAROCK_AVRO_SCHEMA_VERSION \
-    && : "expirationd" \
     && tarantoolctl rocks install expirationd $LUAROCK_EXPERATIOND_VERSION \
-    && : "queue" \
     && tarantoolctl rocks install queue $LUAROCK_QUEUE_VERSION \
-    && : "connpool" \
     && tarantoolctl rocks install connpool $LUAROCK_CONNPOOL_VERSION \
-    && : "http" \
     && tarantoolctl rocks install http $LUAROCK_HTTP_VERSION \
-    && : "pg" \
     && tarantoolctl rocks install pg $LUAROCK_TARANTOOL_PG_VERSION \
-    && : "mysql" \
     && tarantoolctl rocks install mysql $LUAROCK_TARANTOOL_MYSQL_VERSION \
-    && : "memcached" \
     && tarantoolctl rocks install memcached $LUAROCK_MEMCACHED_VERSION \
-    && : "metrics" \
     && tarantoolctl rocks install metrics $LUAROCK_METRICS_VERSION \
-    && : "prometheus" \
     && tarantoolctl rocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && : "gis" \
     && tarantoolctl rocks install gis $LUAROCK_TARANTOOL_GIS_VERSION \
-    && : "gperftools" \
     && tarantoolctl rocks install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION \
     && : "---------- remove build deps ----------" \
     && rm -rf /rocks \
     && yum -y remove \
         git \
         cmake \
-        make \
-        gcc-c++ \
         postgresql96-devel \
-        lua-devel \
         cyrus-sasl-devel \
         libev-devel \
         wget \
@@ -211,12 +92,9 @@ RUN set -x \
         geos-devel \
         openssl-devel \
         kernel-headers \
-        golang-src \
-    && rpm -qa | grep devel | xargs yum -y remove \
-    && rm -rf /var/cache/yum
-
-
-RUN set -x \
+        cpp \
+        perl \
+    && rm -rf /var/cache/yum \
     && : "---------- gosu ----------" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \
        B42F6819007F00F88E364FD4036A9C25BF357DD4 \
@@ -227,17 +105,15 @@ RUN set -x \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
     && rm -r /root/.gnupg/ \
-    && chmod +x /usr/local/bin/gosu
-
-
-RUN mkdir -p /var/lib/tarantool \
+    && chmod +x /usr/local/bin/gosu \
+    && mkdir -p /var/lib/tarantool \
     && chown tarantool:tarantool /var/lib/tarantool \
     && mkdir -p /opt/tarantool \
     && chown tarantool:tarantool /opt/tarantool \
     && mkdir -p /var/run/tarantool \
     && chown tarantool:tarantool /var/run/tarantool \
-    && mkdir /etc/tarantool \
-    && chown tarantool:tarantool /etc/tarantool
+    && chown tarantool:tarantool /etc/tarantool \
+    && ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh
 
 VOLUME /var/lib/tarantool
 WORKDIR /opt/tarantool
@@ -249,7 +125,6 @@ COPY files/console /usr/local/bin/
 COPY files/tarantool_is_up /usr/local/bin/
 COPY files/tarantool.default /usr/local/etc/default/tarantool
 
-RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 HEALTHCHECK CMD tarantool_is_up

--- a/dockerfiles/ubuntu_20.04
+++ b/dockerfiles/ubuntu_20.04
@@ -1,15 +1,12 @@
-FROM ubuntu:20.04
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}ubuntu:20.04
+LABEL org.opencontainers.image.authors="artembo@me.com; piligrim@rootnix.net"
 
-RUN useradd --user-group --create-home --no-log-init --shell /bin/bash tarantool
-
-# An ARG instruction goes out of scope at the end of the build
-# stage where it was defined. To use an arg in multiple stages,
-# each stage must include the ARG instruction
 ARG TNT_VER \
     GC64
 
 ENV GC64=${GC64:-false} \
-    TARANTOOL_VERSION=${TNT_VER:-2} \
+    TARANTOOL_URL=https://www.tarantool.io/release/${TNT_VER:-2}/installer.sh \
     LUAROCK_VSHARD_VERSION=0.1.19 \
     LUAROCK_AVRO_SCHEMA_VERSION=3.0.6 \
     LUAROCK_EXPERATIOND_VERSION=1.1.1 \
@@ -25,10 +22,12 @@ ENV GC64=${GC64:-false} \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
     LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
 
-RUN set -x \ 
+RUN set -x \
+    && useradd --user-group --create-home --no-log-init --shell /bin/bash tarantool \
     && apt update && apt -y --no-install-recommends --no-install-suggests install \
     libgoogle-perftools4 \
     unzip \
+    luarocks \
     libgeos-dev \
     libsasl2-dev \
     libssl-dev \
@@ -39,8 +38,8 @@ RUN set -x \
     curl \
     ca-certificates \
     && ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone \
-    && ln -s /usr/lib/x86_64-linux-gnu/libprofiler.so.0.4.18 /usr/lib/x86_64-linux-gnu/libprofiler.so \
-    && curl -L https://tarantool.io/release/${TARANTOOL_VERSION}/installer.sh | bash \
+    && ln -s /usr/lib/$(arch)-linux-gnu/libprofiler.so.0.4.18 /usr/lib/$(arch)-linux-gnu/libprofiler.so \
+    && curl -L $TARANTOOL_URL | bash \
     && apt -y install tarantool \
     && apt clean \
     && set -x \
@@ -59,7 +58,7 @@ RUN set -x \
     && tarantoolctl rocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && tarantoolctl rocks install gis $LUAROCK_TARANTOOL_GIS_VERSION \
     && tarantoolctl rocks install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION \
-    && apt purge -y unzip curl \
+    && apt purge -y unzip curl git gcc cmake \
     && apt -y autoremove \
     && rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
Due to the long build we decided to create the new images
with Tarantool installed by a packet manager. Not to build
from source like for Alpine linux.

For centos:7 the image the size (compressed) was reduced from 228.29 MB to 141.77 MB
Ubuntu Focal image was added. 

