### PR TITLE
Install gosu version 1.11 on centos 7

### DIFF
--- a/dockerfiles/centos_7
+++ b/dockerfiles/centos_7
@@ -19,7 +19,8 @@ ENV GC64=${GC64:-false} \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.1.0 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.0 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
-    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
+    LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1 \
+    GOSU_VERSION=1.11
 
 COPY files/luarocks-config_centos.lua /usr/local/etc/luarocks/config-5.1.lua
 COPY files/luarocks-config.lua /usr/local/etc/tarantool/rocks/config-5.1.lua
@@ -96,12 +97,9 @@ repo_gpgcheck = 1\n'\
         perl \
     && rm -rf /var/cache/yum \
     && : "---------- gosu ----------" \
-    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \
-       B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && curl -o /usr/local/bin/gosu -SL \
-       "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64" \
-    && curl -o /usr/local/bin/gosu.asc -SL \
-       "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64.asc" \
+    && gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
     && rm -r /root/.gnupg/ \


### PR DESCRIPTION
GOSU version 1.2 fails on start application with error:

    runtime: failed to create new OS thread (have 2 already; errno=22)

Fix #235