### PR TITLE
Fix building images on linux

### DIFF
--- a/.github.mk
+++ b/.github.mk
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 TNT_VER=$(shell cat versions/$${VER:0:1}/${OS}_${DIST}_${VER})
 ROCKS_INSTALLER?='tarantoolctl rocks'
 ENABLE_BUNDLED_LIBYAML?='ON'


### PR DESCRIPTION
Fix the problem with building images on Linux because `make` uses `sh` instead of `bash`, and some features are not compatible with `sh`.
