### PR TITLE
Remove mqtt rock from ubuntu docker image

### DIFF
--- a/dockerfiles/ubuntu_20.04
+++ b/dockerfiles/ubuntu_20.04
@@ -16,7 +16,6 @@ ENV GC64=${GC64:-OFF} \
     LUAROCK_METRICS_VERSION=0.16.0 \
     LUAROCK_TARANTOOL_PG_VERSION=2.0.2 \
     LUAROCK_TARANTOOL_MYSQL_VERSION=2.1.3 \
-    LUAROCK_TARANTOOL_MQTT_VERSION=1.5.1 \
     LUAROCK_TARANTOOL_GIS_VERSION=1.0.1 \
     LUAROCK_TARANTOOL_PROMETHEUS_VERSION=1.0.4 \
     LUAROCK_TARANTOOL_GPERFTOOLS_VERSION=1.0.1
@@ -65,7 +64,6 @@ RUN set -x \
     && tarantoolctl rocks install memcached $LUAROCK_MEMCACHED_VERSION \
     && tarantoolctl rocks install metrics $LUAROCK_METRICS_VERSION \
     && tarantoolctl rocks install prometheus $LUAROCK_TARANTOOL_PROMETHEUS_VERSION \
-    && tarantoolctl rocks install mqtt $LUAROCK_TARANTOOL_MQTT_VERSION \
     && tarantoolctl rocks install gis $LUAROCK_TARANTOOL_GIS_VERSION \
     && tarantoolctl rocks install gperftools $LUAROCK_TARANTOOL_GPERFTOOLS_VERSION \
     && apt purge -y unzip curl git gcc cmake \


### PR DESCRIPTION
Mqtt rock was removed because it can't be installed in ubuntu arm image due to https://github.com/tarantool/mqtt/issues/46.